### PR TITLE
Renaming classes

### DIFF
--- a/src/main/java/BetaDistributionExample.java
+++ b/src/main/java/BetaDistributionExample.java
@@ -19,9 +19,9 @@ package main.java;
 import com.jvstinian.math.InvalidParameterException;
 import com.jvstinian.math.ep.RMSEventLoss;
 import com.jvstinian.math.ep.ReturnPeriod;
-import com.jvstinian.math.ep.SumOfCompoundPoissonScaledBetaDistributionEP;
+import com.jvstinian.math.ep.IndependentCompositePoissonScaledBetaDistributionsEP;
 import com.jvstinian.math.probability.BetaDistribution;
-import com.jvstinian.math.probability.CompoundPoissonScaledBetaDistributionParameters;
+import com.jvstinian.math.probability.CompositePoissonScaledBetaDistributionParameters;
 
 public class BetaDistributionExample {
   /**
@@ -54,13 +54,13 @@ public class BetaDistributionExample {
             new RMSEventLoss(2, 0.1, 300.0, 400.0, 600.0, 5000.0),
             new RMSEventLoss(3, 0.5, 200.0, 300.0, 400.0, 4000.0)
           };
-      CompoundPoissonScaledBetaDistributionParameters[] distparams =
-          new CompoundPoissonScaledBetaDistributionParameters[elt.length];
+      CompositePoissonScaledBetaDistributionParameters[] distparams =
+          new CompositePoissonScaledBetaDistributionParameters[elt.length];
       for (int idx = 0; idx < elt.length; idx++) {
         distparams[idx] = elt[idx].getDistributionParameters();
       }
-      SumOfCompoundPoissonScaledBetaDistributionEP ep =
-          new SumOfCompoundPoissonScaledBetaDistributionEP(distparams);
+      IndependentCompositePoissonScaledBetaDistributionsEP ep =
+          new IndependentCompositePoissonScaledBetaDistributionsEP(distparams);
       double[] opmls = ep.calculateOccurrencePML(rps);
       for (int idx = 0; idx < rps.length; idx++) {
         System.out.print(String.format("%13s", String.valueOf(rps[idx].getReturnPeriod())));

--- a/src/main/java/math/ep/CompositePoissonScaledBetaDistributionEP.java
+++ b/src/main/java/math/ep/CompositePoissonScaledBetaDistributionEP.java
@@ -17,15 +17,15 @@
 package com.jvstinian.math.ep;
 
 import com.jvstinian.math.InvalidParameterException;
-import com.jvstinian.math.probability.CompoundPoissonScaledBetaDistributionParameters;
+import com.jvstinian.math.probability.CompositePoissonScaledBetaDistributionParameters;
 import com.jvstinian.math.probability.ScaledBetaDistribution;
 import com.jvstinian.math.probability.ScaledBetaDistributionParameters;
 import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
 import org.apache.commons.math3.analysis.differentiation.UnivariateDifferentiableFunction;
 
-public class CompoundPoissonScaledBetaDistributionEP
-    extends CompoundPoissonScaledBetaDistributionParameters {
-  public CompoundPoissonScaledBetaDistributionEP(double a, double b, double s, double l)
+public class CompositePoissonScaledBetaDistributionEP
+    extends CompositePoissonScaledBetaDistributionParameters {
+  public CompositePoissonScaledBetaDistributionEP(double a, double b, double s, double l)
       throws InvalidParameterException {
     super(a, b, s, l);
   }

--- a/src/main/java/math/ep/IndependentCompositePoissonScaledBetaDistributionsEP.java
+++ b/src/main/java/math/ep/IndependentCompositePoissonScaledBetaDistributionsEP.java
@@ -16,19 +16,19 @@
 
 package com.jvstinian.math.ep;
 
-import com.jvstinian.math.probability.CompoundPoissonScaledBetaDistributionParameters;
+import com.jvstinian.math.probability.CompositePoissonScaledBetaDistributionParameters;
 import com.jvstinian.math.probability.ScaledBetaDistribution;
 import com.jvstinian.math.probability.ScaledBetaDistributionParameters;
-import com.jvstinian.math.probability.SumOfCompoundPoissonScaledBetaDistributionParameters;
+import com.jvstinian.math.probability.IndependentCompositePoissonScaledBetaDistributionsParameters;
 import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
 import org.apache.commons.math3.analysis.differentiation.UnivariateDifferentiableFunction;
 import org.apache.commons.math3.analysis.solvers.BisectionSolver;
 import org.apache.commons.math3.exception.DimensionMismatchException;
 
-public class SumOfCompoundPoissonScaledBetaDistributionEP
-    extends SumOfCompoundPoissonScaledBetaDistributionParameters {
-  public SumOfCompoundPoissonScaledBetaDistributionEP(
-      CompoundPoissonScaledBetaDistributionParameters[] params) {
+public class IndependentCompositePoissonScaledBetaDistributionsEP
+    extends IndependentCompositePoissonScaledBetaDistributionsParameters {
+  public IndependentCompositePoissonScaledBetaDistributionsEP(
+      CompositePoissonScaledBetaDistributionParameters[] params) {
     super(params);
   }
 

--- a/src/main/java/math/ep/RMSEventLoss.java
+++ b/src/main/java/math/ep/RMSEventLoss.java
@@ -17,7 +17,7 @@
 package com.jvstinian.math.ep;
 
 import com.jvstinian.math.InvalidParameterException;
-import com.jvstinian.math.probability.CompoundPoissonScaledBetaDistributionParameters;
+import com.jvstinian.math.probability.CompositePoissonScaledBetaDistributionParameters;
 
 public class RMSEventLoss {
   private int eventId;
@@ -52,9 +52,9 @@ public class RMSEventLoss {
     return this.rate;
   }
 
-  public CompoundPoissonScaledBetaDistributionParameters getDistributionParameters()
+  public CompositePoissonScaledBetaDistributionParameters getDistributionParameters()
       throws InvalidParameterException {
-    return new CompoundPoissonScaledBetaDistributionParameters(
+    return new CompositePoissonScaledBetaDistributionParameters(
         this.getA(), this.getB(), this.exposure, this.rate);
   }
 }

--- a/src/main/java/math/probability/CompositePoissonScaledBetaDistributionParameters.java
+++ b/src/main/java/math/probability/CompositePoissonScaledBetaDistributionParameters.java
@@ -18,17 +18,17 @@ package com.jvstinian.math.probability;
 
 import com.jvstinian.math.InvalidParameterException;
 
-public class CompoundPoissonScaledBetaDistributionParameters
+public class CompositePoissonScaledBetaDistributionParameters
     extends ScaledBetaDistributionParameters {
   protected double lambda;
 
-  public CompoundPoissonScaledBetaDistributionParameters(double a, double b, double s, double l)
+  public CompositePoissonScaledBetaDistributionParameters(double a, double b, double s, double l)
       throws InvalidParameterException {
     super(a, b, s);
     this.lambda = l;
   }
 
-  public CompoundPoissonScaledBetaDistributionParameters(
+  public CompositePoissonScaledBetaDistributionParameters(
       BetaDistributionParameters params, double s, double l) {
     super(params, s);
     this.lambda = l;

--- a/src/main/java/math/probability/IndependentCompositePoissonScaledBetaDistributionsParameters.java
+++ b/src/main/java/math/probability/IndependentCompositePoissonScaledBetaDistributionsParameters.java
@@ -16,11 +16,11 @@
 
 package com.jvstinian.math.probability;
 
-public class SumOfCompoundPoissonScaledBetaDistributionParameters {
-  protected CompoundPoissonScaledBetaDistributionParameters[] distparams;
+public class IndependentCompositePoissonScaledBetaDistributionsParameters {
+  protected CompositePoissonScaledBetaDistributionParameters[] distparams;
 
-  public SumOfCompoundPoissonScaledBetaDistributionParameters(
-      CompoundPoissonScaledBetaDistributionParameters[] params) {
+  public IndependentCompositePoissonScaledBetaDistributionsParameters(
+      CompositePoissonScaledBetaDistributionParameters[] params) {
     this.distparams = params;
   }
 


### PR DESCRIPTION
Renaming classes to avoid incorrect descriptions of distributions.